### PR TITLE
Change dtype from torch.bool to torch.uint8 to avoid dtype error in torch.stack method

### DIFF
--- a/maskrcnn_benchmark/structures/segmentation_mask.py
+++ b/maskrcnn_benchmark/structures/segmentation_mask.py
@@ -294,7 +294,7 @@ class Polygons(object):
                 )
             except:
                 print([p.numpy() for p in self.polygons])
-                mask = torch.ones((height, width), dtype=torch.bool)
+                mask = torch.ones((height, width), dtype=torch.uint8)
                 return mask
             rle = mask_utils.merge(rles)
             mask = mask_utils.decode(rle)


### PR DESCRIPTION
There is a error occured when trying `torch.stack` different type of data. Change data type from `torch.bool` to `torch.uint8` to avoid `dtype error` in `torch.stack` method. 